### PR TITLE
discard unique variable name generation

### DIFF
--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/GraphElementUtils.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/GraphElementUtils.scala
@@ -39,7 +39,11 @@ object GraphElementUtils {
 
   def generateVariable(prefix: String): String = {
     if (prefix != "") {
-      s"${prefix}_${java.util.UUID.randomUUID.toString.replace("-", "")}"
+      // TODO: think of another way how to make variables in a query uniquely assigned to a query element with same value each time
+      // Commented the line below to make use of Neo4j caching functionality thus drastically improving query performance
+      // The uniqueness of names for graph element variables is left for not to the developer to override in queries with new override parameters in GraphElement
+//      s"${prefix}_${java.util.UUID.randomUUID.toString.replace("-", "")}"
+      prefix
     } else {
       ""
     }

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/BaseQueriesConstructor.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/BaseQueriesConstructor.scala
@@ -41,11 +41,11 @@ class BaseQueriesConstructor[T <: Node](nodeFactory: String => T) {
   // TODO: split this into snippet functions
   def matchConnectingChain(
       sourceNode: T,
-      chain: List[ChainLink],
+      chain: List[ChainLink], // TODO: without control on each graph element having unique variable it's up to calling method to make them distinct. Think of another way to overcome this without a big overhaul of this method
       lineName: String
   ): DeferredQueryBuilder = {
     if (chain.nonEmpty) {
-      c"MATCH" + sourceNode.toSearchObject() +
+      c"MATCH" + sourceNode.toSearchObject("sn") +
         chain.foldLeft(c"") {
           case (a: DeferredQueryBuilder, b: ChainLink) =>
             a + b.relationship.value.toAnyObjectOfType() + b.destinationNode.value.toAnyObjectOfType()} +

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/CreateQueriesConstructor.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/CreateQueriesConstructor.scala
@@ -16,16 +16,16 @@ trait CreateQueriesConstructor {
     relationship.flatMap { r =>
       node2.map { n2 =>
         val result = if (createDuplicateNode2IfPathNotFound) {
-          c"MATCH" + matchArgument.getOrElse(node1.toSearchObject()) +
-            c"MERGE" + node1.toVariableEnclosed() + r.toObject() + n2.toSearchObject() +
-            c"ON MATCH SET" + n2.toVariable() + c"+=" + n2.fields() +
-            c"ON CREATE SET" + n2.toVariable() + c"=" + n2.fields()
+          c"MATCH" + matchArgument.getOrElse(node1.toSearchObject("1")) +
+            c"MERGE" + node1.toVariableEnclosed("1") + r.toObject() + n2.toSearchObject("2") +
+            c"ON MATCH SET" + n2.toVariable("2") + c"+=" + n2.fields() +
+            c"ON CREATE SET" + n2.toVariable("2") + c"=" + n2.fields()
         } else {
-          c"MATCH" + matchArgument.getOrElse(node1.toSearchObject()) +
-            c"MERGE" + n2.toSearchObject() +
-            c"ON MATCH SET" + n2.toVariable() + c"+=" + n2.fields() +
-            c"ON CREATE SET" + n2.toVariable() + c"=" + n2.fields() +
-            c"MERGE" + node1.toVariableEnclosed() + r.toObject() + n2.toVariableEnclosed()
+          c"MATCH" + matchArgument.getOrElse(node1.toSearchObject("1")) +
+            c"MERGE" + n2.toSearchObject("2") +
+            c"ON MATCH SET" + n2.toVariable("2") + c"+=" + n2.fields() +
+            c"ON CREATE SET" + n2.toVariable("2") + c"=" + n2.fields() +
+            c"MERGE" + node1.toVariableEnclosed("1") + r.toObject() + n2.toVariableEnclosed("2")
         }
         relationshipSetArgument.map { rsa =>
           result + rsa

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/DeleteQueriesConstructor.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/DeleteQueriesConstructor.scala
@@ -10,8 +10,8 @@ trait DeleteQueriesConstructor {
       matchNode: Node,
       relationshipToDelete: RelationshipRight,
       nodeToDelete: Node): DeferredQueryBuilder = {
-    c"MATCH" + matchNode.toObject() + relationshipToDelete.toSearchObject() + nodeToDelete.toSearchObject() +
-      c"DELETE" + relationshipToDelete.toVariable() + "," + nodeToDelete.toVariable()
+    c"MATCH" + matchNode.toObject("mn") + relationshipToDelete.toSearchObject() + nodeToDelete.toSearchObject("nd") +
+      c"DELETE" + relationshipToDelete.toVariable() + "," + nodeToDelete.toVariable("nd")
   }
 
   def deleteDetachedNodesQuery(nodeClass: NodeClass): DeferredQueryBuilder = {


### PR DESCRIPTION
Discarded the uniqueness in variable name generation to get better advantage of neo4j caching of queries. Refactored `GraphElement` to allow variable name overrides and updated all queries to support the new way.

Reminder: Think in the future how to:
- resolve this situation without manual overrides
- update `BaseQueriesConstructor` fully support the new scheme
- ditch this library altogether and find a better way of querying Neo4j without the need for all this boilerplate (Better)
