### PR TITLE
use right version for line html and md marshalling

### DIFF
--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineHTMLSupport.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineHTMLSupport.scala
@@ -27,7 +27,7 @@ object LineHTMLSupport extends HTMLSupport[Line] {
     Marshaller.withOpenCharset(MediaTypes.`text/html`) { case (line, charset) =>
       HttpResponse(entity = HttpEntity(
         ContentType(MediaTypes.`text/html`, charset),
-        generateLineHTML(line)))
+        generateLineHTML(LineV1.toLineV1(line))))
     }
   }
 
@@ -39,27 +39,16 @@ object LineHTMLSupport extends HTMLSupport[Line] {
     Marshaller.withFixedContentType(MediaVersionTypes.`text/moonlight.v1+html`) { line =>
       HttpResponse(entity = HttpEntity(
         ContentType(MediaVersionTypes.`text/moonlight.v1+html`),
-        generateLineV1HTML(LineV1.toLineV1(line))))
+        generateLineHTML(LineV1.toLineV1(line))))
     }
   }
 
-  private def generateLineHTML(line: Line)(
+  private def generateLineHTML(line: LineV1)(
       implicit executionContext: ExecutionContext,
       lineMDGenerator: LineMDGenerator,
       lineHTMLGenerator: LineHTMLGenerator): String = {
     val result = for {
       lineMD <- lineMDGenerator.generateMd(line)
-      lineHTML <- lineHTMLGenerator.generateHTML(lineMD)
-    } yield lineHTML
-    result.getOrElse(throw new LineHTMLGenerationException("Error generating line HTML!"))
-  }
-
-  private def generateLineV1HTML(line: LineV1)(
-      implicit executionContext: ExecutionContext,
-      lineMDGenerator: LineMDGenerator,
-      lineHTMLGenerator: LineHTMLGenerator): String = {
-    val result = for {
-      lineMD <- lineMDGenerator.generateMdV1(line)
       lineHTML <- lineHTMLGenerator.generateHTML(lineMD)
     } yield lineHTML
     result.getOrElse(throw new LineHTMLGenerationException("Error generating line HTML!"))

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineMDGenerator.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineMDGenerator.scala
@@ -5,29 +5,7 @@ import com.github.jamedge.moonlight.core.model.{Alert, Code, IOElement, Line, Me
 import scala.util.Try
 
 class LineMDGenerator {
-  def generateMd(line: Line): Try[String] = {
-    Try {
-      val naString = "<NA>"
-      val result =
-        s"""Property name|Property value
-           |-------------|--------------
-           |Name|**${line.name}**
-           |Owner|${line.owner.getOrElse(naString)}
-           |Purpose|${line.purpose.getOrElse(naString)}
-           |Notes|${line.notes.getOrElse(List()).map(n => s"_${n}_").mkString(", ")}
-           |Inputs|${line.io.flatMap(io => generateIOCaptions(io.inputs)).mkString(", ")}
-           |Outputs|${line.io.flatMap(io => generateIOCaptions(io.outputs)).mkString(", ")}
-           |Processed by|${generateProcessCaptions(line.processedBy).mkString(", ")}
-           |Metrics|${generateMetricsCaptions(line.metrics).mkString(", ")}
-           |Alerts|${generateAlertsCaptions(line.alerts).mkString(", ")}
-           |Code path|${line.code.map(c => s"[${c.name}](${c.remotePath})").getOrElse(naString)}
-           |Execution command entry point|${line.code.map(c => generateExecutionCommand(c)).getOrElse(naString)}
-          """.stripMargin
-      result
-    }
-  }
-
-  def generateMdV1(line: LineV1): Try[String] = {
+  def generateMd(line: LineV1): Try[String] = {
     Try {
       val naString = "<NA>"
       val result =

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineMDSupport.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/api/versioning/line/LineMDSupport.scala
@@ -25,7 +25,9 @@ object LineMDSupport extends MDSupport[Line] {
     Marshaller.withOpenCharset(MediaTypes.`text/markdown`) { case (line, charset) =>
       HttpResponse(entity = HttpEntity(
         ContentType(MediaTypes.`text/markdown`, charset),
-        lineMDGenerator.generateMd(line).getOrElse(throw new LineMDGenerationException("Error generating line MD!"))))
+        lineMDGenerator.
+          generateMd(LineV1.toLineV1(line)).
+          getOrElse(throw new LineMDGenerationException("Error generating line MD!"))))
     }
   }
 
@@ -37,7 +39,7 @@ object LineMDSupport extends MDSupport[Line] {
       HttpResponse(entity = HttpEntity(
         ContentType(MediaVersionTypes.`text/moonlight.v1+markdown`),
         lineMDGenerator.
-          generateMdV1(LineV1.toLineV1(line)).
+          generateMd(LineV1.toLineV1(line)).
           getOrElse(throw new LineMDGenerationException("Error generating line MD!"))))
     }
   }


### PR DESCRIPTION
- bugfix as the wrong version of the line was used in the general case when the version wasn't specified