### PR TITLE
enable deletion of the line on each update

### DIFF
--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/DeleteQueriesConstructor.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/model/neo4j/queries/DeleteQueriesConstructor.scala
@@ -1,7 +1,6 @@
 package com.github.jamedge.moonlight.core.model.neo4j.queries
 
-import com.github.jamedge.moonlight.core.model.neo4j.NodeClass
-import com.github.jamedge.moonlight.core.model.neo4j.{Node, RelationshipRight}
+import com.github.jamedge.moonlight.core.model.neo4j.{ElementClass, Node, NodeClass, RelationshipRight}
 import neotypes.DeferredQueryBuilder
 import neotypes.implicits.all._
 
@@ -15,7 +14,7 @@ trait DeleteQueriesConstructor {
   }
 
   def deleteDetachedNodesQuery(nodeClass: NodeClass): DeferredQueryBuilder = {
-    c"MATCH" + s"(i:${nodeClass.name})" + c"WHERE NOT (i) <-- () DELETE i"
+    c"MATCH" + s"(i:${nodeClass.name})" + s"WHERE NOT (i) ${ if (nodeClass == ElementClass.Line) "-->" else "<--" } () DELETE i"
   }
 
   def deleteCleanedRelationships(): DeferredQueryBuilder = {

--- a/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/service/line/LinePersistenceLayer.scala
+++ b/moonlight-core/src/main/scala/com/github/jamedge/moonlight/core/service/line/LinePersistenceLayer.scala
@@ -6,7 +6,7 @@ import com.github.jamedge.moonlight.core.model.neo4j.queries.{ChainLink, LineQue
 import neotypes.{DeferredQuery, Driver, Transaction}
 import shapeless.Id
 import neotypes.implicits.all._
-import org.neo4j.driver.v1.{Session, Value}
+import org.neo4j.driver.v1.Value
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -283,7 +283,8 @@ class LinePersistenceLayer(
       constructDeleteDetachedNodes(ElementClass.MetricsFramework).execute(tx),
       constructDeleteDetachedNodes(ElementClass.Process).execute(tx),
       constructDeleteDetachedNodes(ElementClass.ProcessingFramework).execute(tx),
-      constructDeleteDetachedNodes(ElementClass.Code).execute(tx)
+      constructDeleteDetachedNodes(ElementClass.Code).execute(tx),
+      constructDeleteDetachedNodes(ElementClass.Line).execute(tx)
     ))
   }
 


### PR DESCRIPTION
- There was a bugfix in updating line details, happening because line node wasn't being recreated like the others. This bugfix takes care of that.